### PR TITLE
Fix for building in Xcode 5, use performSelector for UIDevice uniqueIdentifier.

### DIFF
--- a/BPXLUUIDHandler.m
+++ b/BPXLUUIDHandler.m
@@ -102,7 +102,9 @@ static CFMutableDictionaryRef CreateKeychainQueryDictionary(void)
 #if TARGET_IPHONE_SIMULATOR
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	return [[UIDevice currentDevice] uniqueIdentifier];
+	if ([[UIDevice currentDevice] respondsToSelector:@selector(uniqueIdentifier)]) {
+		return [[UIDevice currentDevice] performSelector:@selector(uniqueIdentifier)];
+	}
 #pragma clang diagnostic pop
 #endif
 	CFUUIDRef uuidRef = CFUUIDCreate(NULL);


### PR DESCRIPTION
This code no longer builds when using Xcode 5 because BPXLUUIDHandler calls UIDevice's -uniqueIdentifier method, which no longer exists. This change just only uses uniqueIdentifier if it is available. Note that this code only applies to the simulator, so for newer simulators it will generate a new UUID same as real devices.

![screen shot 2013-07-10 at 11 58 07 am copy](https://f.cloud.github.com/assets/631074/777502/38e75482-e99a-11e2-8ad4-cb384de526f1.png)
